### PR TITLE
fix run_test.m on Windows

### DIFF
--- a/tests/test_json.m
+++ b/tests/test_json.m
@@ -118,7 +118,7 @@ run_test(InputFileName, !IO) :-
             io.close_output(OutputFile, !IO),
             ExpFileName = BaseFileName ++ ".exp",
             ResFileName = BaseFileName ++ ".res",
-            string.format("diff -u %s %s > %s",
+            string.format("diff --strip-trailing-cr -u %s %s >%s",
                 [s(ExpFileName), s(OutputFileName), s(ResFileName)],
                 DiffCmd),
             io.call_system(DiffCmd, DiffCmdRes, !IO),

--- a/tests/test_json.m
+++ b/tests/test_json.m
@@ -185,7 +185,7 @@ parse_and_output(BaseFileName, Input, Output, !IO) :-
         Result = error(Error),
         Msg = stream.error_message(Error),
         io.write_string(Output, Msg, !IO)
-    ). 
+    ).
 
 :- pred override_default_params(string::in,
     allow_comments::out, allow_trailing_commas::out,

--- a/tests/test_json.m
+++ b/tests/test_json.m
@@ -118,8 +118,8 @@ run_test(InputFileName, !IO) :-
             io.close_output(OutputFile, !IO),
             ExpFileName = BaseFileName ++ ".exp",
             ResFileName = BaseFileName ++ ".res",
-            string.format("diff --strip-trailing-cr -u %s %s >%s",
-                [s(ExpFileName), s(OutputFileName), s(ResFileName)],
+            string.format("sed -e 's/\\r\\n/\\n/' <%s | diff -u %s - >%s",
+                [s(OutputFileName), s(ExpFileName), s(ResFileName)],
                 DiffCmd),
             io.call_system(DiffCmd, DiffCmdRes, !IO),
             (


### PR DESCRIPTION
On windows, testing needs to strip \r, since the *.exp files are eol=\n and Mercury output is
using the native line ending by default (c.f. io.(write|print)_line/3)
Nevertheless, not all tests pass, but before, all test aborted since the exit code was 1.
There is another potential bug, it should have hit the "FAILED" disjunction, but maybe io.call_system/3 works this way.

tests/test_json.m:
    on line 121, added --strip-trailing-cr parameter (which is available in msys diff)
